### PR TITLE
Add save-prefix config to prevent version drift

### DIFF
--- a/crawler-agent-core/.npmrc
+++ b/crawler-agent-core/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/crawler-agent-fe/.yarnrc
+++ b/crawler-agent-fe/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""

--- a/crawler-bot-protection-proxy/.yarnrc
+++ b/crawler-bot-protection-proxy/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
No pins were needed. An independent scan of every manifest found zero range specifiers, so this only adds the setting that stops new ones appearing.

- `crawler-agent-core/.npmrc`, `crawler-agent-fe/.yarnrc`, and `crawler-bot-protection-proxy/.yarnrc`: core is npm while the other two are yarn, so each root gets the setting for its own manager
